### PR TITLE
Allow passing a model to route

### DIFF
--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -224,14 +224,14 @@ class HtmlBuilder
      *
      * @param string $name
      * @param string|null $title
-     * @param array $parameters
+     * @param mixed $parameters
      * @param array $attributes
      * @param bool|null $secure
      * @param bool $escape
      *
      * @return string
      */
-    public function linkRoute(string $name, string $title = null, array $parameters = [], array $attributes = [], bool $secure = null, bool $escape = true): string
+    public function linkRoute(string $name, string $title = null, mixed $parameters = [], array $attributes = [], bool $secure = null, bool $escape = true): string
     {
         return $this->link($this->url->route($name, $parameters), $title, $attributes, $secure, $escape);
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -43,12 +43,12 @@ if (! function_exists('link_to_route')) {
      *
      * @param string $name
      * @param string|null $title
-     * @param array $parameters
+     * @param mixed $parameters
      * @param array $attributes
      *
      * @return string
      */
-    function link_to_route(string $name, string $title = null, array $parameters = [], array $attributes = []): string
+    function link_to_route(string $name, string $title = null, mixed $parameters = [], array $attributes = []): string
     {
         return app('html')->linkRoute($name, $title, $parameters, $attributes);
     }


### PR DESCRIPTION
Example:

`link_to_route('system.user.show', 'Show profile', $user)`

It worked in the previous version as `route()` from Laravel allows such construction 