### PR TITLE
Fix broken select

### DIFF
--- a/config/html-forms.php
+++ b/config/html-forms.php
@@ -11,7 +11,8 @@ return [
          */
         'all' => [
             'disabled',
-            'checked'
+            'checked',
+            'value'
         ],
 
         /**


### PR DESCRIPTION
Assuming such select:

`Form::select('test', ['' => 'Placeholder', 'value' => 'label']);`

we would expect to get an empty string if we select the first option and "value" in the case of choosing the second.

At it worked in this way in the original version of this library. Now selecting first will send to the controller "Placeholder". It is caused by a missing "value" attribute.

![image](https://github.com/LaravelLux/html/assets/17027876/ec0729cc-76eb-47f9-b242-54db34507e54)
![image](https://github.com/LaravelLux/html/assets/17027876/885b0731-eb38-4a46-a385-4e105d8175bf)

Adding a "value" to the config resolves this issue, but I am not sure if is it the intended default behavior at all. 



