### PR TITLE
Allow Form::select's value to stay integer

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -772,7 +772,7 @@ class FormBuilder
      *
      * @return HtmlString|string
      */
-    public function getSelectOption(string|array|Collection $display, string $value, string|array|Collection|null $selected, array $attributes = [], array $optgroupAttributes = []): HtmlString|string
+    public function getSelectOption(string|array|Collection $display, string|int $value, string|array|Collection|null $selected, array $attributes = [], array $optgroupAttributes = []): HtmlString|string
     {
         if (is_iterable($display)) {
             return $this->optionGroup($display, $value, $selected, $optgroupAttributes, $attributes);
@@ -818,7 +818,7 @@ class FormBuilder
      *
      * @return HtmlString|string
      */
-    protected function option(string|null $display, string $value, string|array|Collection|null $selected = null, array $attributes = []): HtmlString|string
+    protected function option(string|null $display, string|int $value, string|array|Collection|null $selected = null, array $attributes = []): HtmlString|string
     {
         $selected = $this->getSelectedValue($value, $selected);
 


### PR DESCRIPTION
For selects with multiple attribute, where the options are integers, there is a bug where the option values are converted to string preventing the getSelectedValue method to compare it with the elements in the $selected array.
To reproduce the error try to run:

`Form::select('name', [5=>'asdf'], [5], ['multiple'=>'multiple'])`

This shoult add a selected attribute to the option tag:

`<select multiple="multiple" name="name"><option value="5" selected="selected">asdf</option></select>`

Instead it just leaves it unselected:

`<select multiple="multiple" name="name"><option value="5">asdf</option></select>`