### PR TITLE
strict types bug fixed

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1310,7 +1310,7 @@ class FormBuilder
             return $attributes['id'];
         }
 
-        if (in_array($name, $this->labels)) {
+        if (in_array($name, $this->labels, true)) {
             return $name;
         }
         return '';

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -899,6 +899,14 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('<input class="class-a class-c" name="test" type="text">', $input);
     }
 
+    public function testInputWithEmptyLabel()
+    {
+        $this->formBuilder->label('');
+        $input = $this->formBuilder->submit('button');
+
+        $this->assertEquals('<input type="submit" value="button">', $input);
+    }
+
     protected function setModel(array $data, $object = true)
     {
         if ($object) {


### PR DESCRIPTION
Today I stumbled upon a thing. If there's an empty label within the list and you add a submit button (that doesn't contain identifier), the code tries to return `null` name that violates method signature.

This PR adds strict check in order to make sure that empty string (not null) is returned.

Added a test for this.